### PR TITLE
add option for instant alien health

### DIFF
--- a/lua/CHUD_Options.lua
+++ b/lua/CHUD_Options.lua
@@ -157,7 +157,19 @@ CHUDOptions =
 				valueType = "int",
 				applyFunction = function() CHUDRestartScripts({	"GUIAlienHUD" }) end,
 				sort = "C2",
-			}, 
+			},
+			instantalienhealth = {
+				name    = "CHUD_InstantAlienHealth",
+				label   = "Instant Alien Health Bar",
+				tooltip = "Update alien health bar instantly instead of animating.",
+				type    = "select",
+				values  = { "Off", "On" },
+				callback = CHUDSaveMenuSettings,
+				defaultValue = false,
+				category = "func",
+				valueType = "bool",
+				sort = "C2"
+			},
 			dmgcolor_m = {
 				name    = "CHUD_DMGColorM",
 				label   = "Marine damage numbers color",


### PR DESCRIPTION
yo, this is kmg

This adds an option called "Instant Alien Health Bar" which turns off all animation on the alien health ball (health and armor). I haven't worked with NS2Plus or done any NS2 modding before really, so hopefully I got the conventions somewhere close to correct. Let me know if there are any changes I could make so that it fits better.

This is just something that has bugged me for a while, when I take a shell as a fade I want to know how low I am as soon as possible :P

There may of course be issues with this I overlooked, I'm just a lowly noob, but I'd be very appreciative of a merge.
