### PR TITLE
add server option to make drop packs ignore y axis

### DIFF
--- a/lua/Server/CHUD_DropPack.lua
+++ b/lua/Server/CHUD_DropPack.lua
@@ -1,0 +1,30 @@
+originalDropPackOnUpdate = Class_ReplaceMethod( "DropPack", "OnUpdate",
+	function(self, deltaTime)
+		if not CHUDServerOptions["droppacksignorey"].currentValue then
+			originalDropPackOnUpdate(self, deltaTime)
+			return
+		end
+
+		-- GetEntitiesForTeamWithinXZRange ignores the Y axis
+		local marinesNearby = GetEntitiesForTeamWithinXZRange("Marine", self:GetTeamNumber(), self:GetOrigin(), self.pickupRange)
+		Shared.SortEntitiesByDistance(self:GetOrigin(), marinesNearby)
+
+		local pickedUp = false
+		for _, marine in ipairs(marinesNearby) do
+
+			if self:GetIsValidRecipient(marine) then
+
+				self:OnTouch(marine)
+				DestroyEntity(self)
+				pickedUp = true
+			break
+
+		end
+
+		end
+
+		if not pickedUp then
+			originalDropPackOnUpdate(self, deltaTime)
+		end
+	end
+)

--- a/lua/Server/CHUD_Server.lua
+++ b/lua/Server/CHUD_Server.lua
@@ -13,6 +13,7 @@ Script.Load("lua/Server/CHUD_MarineTeam.lua")
 Script.Load("lua/Server/CHUD_PlayerInfo.lua")
 Script.Load("lua/Server/CHUD_PowerPoint.lua")
 Script.Load("lua/Server/CHUD_PickupExpire.lua")
+Script.Load("lua/Server/CHUD_DropPack.lua")
 
 local oldBadgesActive = false
 // Warning about outdated mod

--- a/lua/Server/CHUD_ServerSettings.lua
+++ b/lua/Server/CHUD_ServerSettings.lua
@@ -55,6 +55,12 @@ CHUDServerOptions =
 		valueType = "bool",
 		defaultValue = true,
 		},
+	droppacksignorey = {
+		label   = "Drop packs ignore Y axis",
+		tooltip = "If true med / ammo packs ignore Y axis.",
+		valueType = "bool",
+		defaultValue = true,
+		}
 }
 
 local configFileName = "NS2PlusServerConfig.json"


### PR DESCRIPTION
this is an adjustment somebody on the forums suggested, and i'm surprised i hadn't thought of it before. this makes drop packs (meds, ammo, etc.) ignore the Y axis. 

in some scenarios this will cause an extra check for pickups, but this method is less intrusive than replacing the entire original method outright. i've done some basic testing on it and it seemed fine, but i haven't actually figured out how to test changing server options in a listen server :P so somebody might want to try out the actual option. it looks right to me though. dunno if this should be defaulted to true or not. 

the relevant bit here is that <tt>GetEntitiesForTeamWithinRange</tt> is switched out for <tt>GetEntitiesForTeamWithinXZRange</tt>, which i was really glad to find.

hopefully you like it!
