### PR TITLE
show BoneWall blip on minimap

### DIFF
--- a/lua/Shared/CHUD_BoneWall.lua
+++ b/lua/Shared/CHUD_BoneWall.lua
@@ -1,0 +1,41 @@
+-- we need to completly replace the kMinimapBlipType enum because an enum cannot
+-- be altered after creation. so, we're basically going to clone as just a
+-- regular table instead of an enum. should be fine I guess, apparently enums
+-- are just tables anyway.
+local blipTypes = {}
+local maxVal, key = 0
+for k, v in pairs(kMinimapBlipType) do
+	if type(v) == number and v > maxVal then
+		maxVal, key = v, k
+	end
+	blipTypes[k] = v
+end
+
+-- append the entry for BoneWall, effectively registering it as a new blip type
+blipTypes["BoneWall"] = maxVal + 1
+blipTypes[maxVal + 1] = "BoneWall"
+kMinimapBlipType = blipTypes
+
+-- ClassToGrid is a map of class names to a grid position on the spritesheet
+-- ui/minimap_blip.dds and it's defined in NS2Utility.lua
+local originalBuildClassToGrid = BuildClassToGrid
+function BuildClassToGrid()
+	local map = originalBuildClassToGrid()
+
+	-- 8,3 is apparently a "Kill" blip, which i think is unused. it seems to suit
+	-- our purposes okay, but if need be there's room to add another blip. not
+	-- sure what a BoneWall blip would look like anyway.
+	map["BoneWall"] = { 8, 3 }
+	return map
+end
+
+-- add the MapBlipMixin to BoneWall
+if Server then
+	originalBoneWallOnCreate = Class_ReplaceMethod( "BoneWall", "OnCreate",
+		function(self)
+			originalBoneWallOnCreate(self)
+
+			InitMixin(self, MapBlipMixin)
+		end
+	)
+end

--- a/lua/Shared/CHUD_Shared.lua
+++ b/lua/Shared/CHUD_Shared.lua
@@ -30,6 +30,7 @@ Script.Load("lua/Shared/CHUD_CommanderSelection.lua")
 Script.Load("lua/Shared/CHUD_LayMines.lua")
 Script.Load("lua/Shared/CHUD_AmmoPack.lua")
 Script.Load("lua/Shared/CHUD_Grenade.lua")
+Script.Load("lua/Shared/CHUD_BoneWall.lua")
 
 CHUDTagBitmask = {
 	mcr = 0x1,


### PR DESCRIPTION
lost my fade to a friendly bone wall earlier that i didn't know was there, and it frustrated me :P

this is using the sprite for something called "Kill" from minimap_blip.dds. I don't know what it's supposed to be, but I think it's unused. It sorta makes sense as a bone wall, I mostly just didn't want to make a new sprite and override that whole file. i'm not sure what a bone wall blip would look like anyway. 

also i just noticed i used lua-style comments instead of c-style comments. let me know if you want me to fix that. why does UWE do that anyway?
