### PR TITLE
Nameplate distance has been changed in 297 to render from further awa…

### DIFF
--- a/lua/NS2Plus/Client/CHUD_Options.lua
+++ b/lua/NS2Plus/Client/CHUD_Options.lua
@@ -601,18 +601,6 @@ CHUDOptions =
 				applyFunction = function() CHUDRestartScripts({ "GUIUnitStatus" }) end,
 				sort = "A07",
 			},
-			nameplatesdistance = {
-				name = "CHUD_Nameplates_Distance",
-				label = "Nameplates Distance",
-				tooltip = "Chooses how far away, in meters, the nameplates render (ie. when aiming at a building to check its health). This includes teammate names while not aiming at them. High values will decrease performance.",
-				type = "slider",
-				defaultValue = 13,
-				minValue = 5,
-				maxValue = 30,
-				category = "hud",
-				valueType = "float",
-				sort = "A08",
-			},
 			score = {
 				name = "CHUD_ScorePopup",
 				label = "Score popup",

--- a/lua/NS2Plus/GUIScripts/GUIUnitStatus.lua
+++ b/lua/NS2Plus/GUIScripts/GUIUnitStatus.lua
@@ -145,8 +145,6 @@ oldUnitStatusInit = Class_ReplaceMethod( "GUIUnitStatus", "Initialize",
 local oldUnitStatusUpdate
 oldUnitStatusUpdate = Class_ReplaceMethod( "GUIUnitStatus", "Update",
 	function(self, deltaTime)
-		GUIUnitStatus.kMaxUnitStatusDistance = ConditionalValue(PlayerUI_GetIsSpecating(), 30, CHUDGetOption("nameplatesdistance"))
-		
 		CHUDHint = true
 		oldUnitStatusUpdate( self, deltaTime )
 		CHUDHint = false


### PR DESCRIPTION
…y for marked enemies and crosshair targets. Leaving this option in may lead to unintentional side effects / extra advantage beyond intended distances
