### PR TITLE
Fix bug preventing NSL player info scoreboard menu from being added

### DIFF
--- a/lua/NS2Plus/GUIScripts/GUIScoreboard.lua
+++ b/lua/NS2Plus/GUIScripts/GUIScoreboard.lua
@@ -247,7 +247,7 @@ if GetNSLMode then
 				for index, entry in ipairs(self.hoverMenu.links) do
 					if not entry.isSeparator then
 						local text = entry.link:GetText()
-						if text == Locale.ResolveString("SB_MENU_HIVE_PROFILE") then
+						if text == Locale.ResolveString("SB_MENU_STEAM_PROFILE") then
 							teamColorBg = entry.bgColor
 							teamColorHighlight = entry.bgHighlightColor
 							found = index


### PR DESCRIPTION
NS2+ now adds the NSL player info scoreboard menu right below vanilla's
Steam player info. Previously NS2+ looked for vanilla's hive player info,
which was recently removed, and so displayed nothing.

Note that this is just as prone to future failure as the original implementation, 
but at least this works currently. Mendasp added the NSL menu specifically 
after the hive player info (and not after the last entry), which I assume there is 
a reason for.