### PR TITLE
Add research time to overhead view tech tooltips

### DIFF
--- a/lua/NS2Plus/Client/CHUD_Options.lua
+++ b/lua/NS2Plus/Client/CHUD_Options.lua
@@ -1529,4 +1529,15 @@ CHUDOptions =
 				valueType = "bool",
 				sort = "B02",
 			},
+			researchtimetooltip = {
+				name = "CHUD_ResearchTimeTooltip",
+				label = "(Comm) Research Time Tooltip",
+				tooltip = "Displays the time remaining when hovering over the research icon.",
+				type = "select",
+				values = { "Off", "On" },
+				defaultValue = false,
+				category = "misc",
+				valueType = "bool",
+				sort = "B03",
+			}
 }

--- a/lua/NS2Plus/GUIScripts/GUIProduction.lua
+++ b/lua/NS2Plus/GUIScripts/GUIProduction.lua
@@ -124,7 +124,10 @@ originalUpdateClientEffects = Class_ReplaceMethod( "Commander", "UpdateClientEff
 		originalUpdateClientEffects(self, deltaTime, isLocal)
 		
 		found = false
-		self.production.InProgress:ForEach(displayTimeTooltip)
+		
+		if CHUDGetOption("researchtimetooltip") then
+			self.production.InProgress:ForEach(displayTimeTooltip)
+		end
 		
 		if found then
 			self.tooltip:SetText(tooltipText)

--- a/lua/NS2Plus/GUIScripts/GUIProduction.lua
+++ b/lua/NS2Plus/GUIScripts/GUIProduction.lua
@@ -1,11 +1,36 @@
 local tooltipText = ""
 local found = false
 local foundTime = -1
-local function displayTooltip(tech)
+local function displayNameTooltip(tech)
 	if GUIItemContainsPoint(tech.Icon, Client.GetCursorPosScreen()) then
 		found = true
 		foundTime = Shared.GetTime(true)
 		tooltipText = GetDisplayNameForTechId(tech.Id)
+	end
+end
+
+local function displayNameTimeTooltip(tech)
+	if GUIItemContainsPoint(tech.Icon, Client.GetCursorPosScreen()) then
+		found = true
+		foundTime = Shared.GetTime(true)
+		tooltipText = GetDisplayNameForTechId(tech.Id)
+		
+		local timeLeft = tech.StartTime + tech.ResearchTime - Shared.GetTime()
+		local minutes = math.floor(timeLeft/60)
+		local seconds = math.ceil(timeLeft - minutes*60)
+		tooltipText = string.format("%s - %01.0f:%02.0f", tooltipText, minutes, seconds)
+	end
+end
+
+local function displayTimeTooltip(tech)
+	if GUIItemContainsPoint(tech.Icon, Client.GetCursorPosScreen()) then
+		found = true
+		foundTime = Shared.GetTime(true)
+		
+		local timeLeft = tech.StartTime + tech.ResearchTime - Shared.GetTime()
+		local minutes = math.floor(timeLeft/60)
+		local seconds = math.ceil(timeLeft - minutes*60)
+		tooltipText = string.format("%01.0f:%02.0f", minutes, seconds)
 	end
 end
 
@@ -55,11 +80,52 @@ originalSpectatorUpdate = Class_ReplaceMethod( "GUISpectator", "Update",
 		originalSpectatorUpdate(self, deltaTime)
 		
 		found = false
-		self.guiMarineProduction.InProgress:ForEach(displayTooltip)
-		self.guiMarineProduction.Complete:ForEach(displayTooltip)
-		self.guiAlienProduction.InProgress:ForEach(displayTooltip)
-		self.guiAlienProduction.Complete:ForEach(displayTooltip)
+		self.guiMarineProduction.InProgress:ForEach(displayNameTimeTooltip)
+		self.guiMarineProduction.Complete:ForEach(displayNameTooltip)
+		self.guiAlienProduction.InProgress:ForEach(displayNameTimeTooltip)
+		self.guiAlienProduction.Complete:ForEach(displayNameTooltip)
 			
+		if found then
+			self.tooltip:SetText(tooltipText)
+			self.tooltip:Show()
+		elseif foundTime > -1 and foundTime + 0.1 < Shared.GetTime(true) then
+			self.tooltip:Hide()
+			foundTime = -1
+		end
+	end)
+
+local originalCommanderOnInit
+originalCommanderOnInit = Class_ReplaceMethod( "Commander", "OnInitLocalClient",
+	function(self)
+		originalCommanderOnInit(self)
+		
+		self.tooltip = GetGUIManager():CreateGUIScriptSingle("menu/GUIHoverTooltip")
+		tooltipText = ""
+		found = false
+		foundTime = -1
+	end)
+
+local originalCommanderOnDestroy
+originalCommanderOnDestroy = Class_ReplaceMethod( "Commander", "OnDestroy",
+	function(self)
+		originalCommanderOnDestroy(self)
+		
+		self.tooltip = GetGUIManager():CreateGUIScriptSingle("menu/GUIHoverTooltip")
+		tooltipText = ""
+		found = false
+		
+		self.tooltip:Hide(0)
+		foundTime = -1
+	end)
+
+local originalUpdateClientEffects
+originalUpdateClientEffects = Class_ReplaceMethod( "Commander", "UpdateClientEffects",
+	function(self, deltaTime, isLocal)
+		originalUpdateClientEffects(self, deltaTime, isLocal)
+		
+		found = false
+		self.production.InProgress:ForEach(displayTimeTooltip)
+		
 		if found then
 			self.tooltip:SetText(tooltipText)
 			self.tooltip:Show()


### PR DESCRIPTION
Spectators' tooltips now also show the time remaining until
the research is complete, in addition to the research name. 
[picture](https://i.imgur.com/2s7xhlv.jpg) 
Commanders' tooltips just show the time remaining, without
the research name.
Commanders' tooltips can be disabled (default) or enabled 
from the settings menu.