### PR TITLE
Customize the alien hive status UI

### DIFF
--- a/lua/NS2Plus/CHUD_GUIScripts.lua
+++ b/lua/NS2Plus/CHUD_GUIScripts.lua
@@ -30,6 +30,7 @@ Script.Load("lua/NS2Plus/GUIScripts/GUIInventory.lua")
 Script.Load("lua/NS2Plus/GUIScripts/GUIProduction.lua")
 Script.Load("lua/NS2Plus/GUIScripts/GUIFeedback.lua")
 Script.Load("lua/NS2Plus/GUIScripts/GUIJetpackFuel.lua")
+Script.Load("lua/NS2Plus/GUIScripts/GUIHiveStatus.lua")
 
 GetGUIManager():CreateGUIScript("NS2Plus/Client/CHUDGUI_DeathStats")
 GetGUIManager():CreateGUIScript("NS2Plus/Client/CHUDGUI_EndStats")

--- a/lua/NS2Plus/Client/CHUD_Options.lua
+++ b/lua/NS2Plus/Client/CHUD_Options.lua
@@ -40,6 +40,7 @@ CHUDOptions =
 				applyFunction = function() CHUDRestartScripts({
 					"Hud/Marine/GUIMarineHUD",
 					"GUIAlienHUD",
+					"GUIHiveStatus",
 					}) end,
 				sort = "A01",
 			},
@@ -146,6 +147,20 @@ CHUDOptions =
 				sort = "A08",
 			},
 			
+			hivestatus = {
+				name = "CHUD_HiveStatus",
+				label = "Alien Hive Status UI",
+				tooltip = "Enables or disables the hive status display in the top left of the alien HUD.",
+				type = "select",
+				values = {"On", "Off"},
+				defaultValue = false,
+				category = "ui",
+				valueType = "bool",
+				applyFunction = function() CHUDRestartScripts({
+					"GUIHiveStatus",
+					}) end,
+				sort = "B00.5",
+			},
 			minimap = {
 				name = "CHUD_Minimap",
 				label = "Marine minimap",

--- a/lua/NS2Plus/GUIScripts/GUIHiveStatus.lua
+++ b/lua/NS2Plus/GUIScripts/GUIHiveStatus.lua
@@ -1,0 +1,22 @@
+local originalInit
+originalInit = Class_ReplaceMethod( "GUIHiveStatus", "Initialize", 
+	function(self)
+		originalInit(self)
+		
+		local hivestatus = not CHUDGetOption("hivestatus")
+		
+		self:SetIsVisible(hivestatus)
+	end)
+
+local originalCreateStatusContainer
+originalCreateStatusContainer = Class_ReplaceMethod( "GUIHiveStatus", "CreateStatusContainer",
+	function(self, slotIdx, locationId)
+		originalCreateStatusContainer(self, slotIdx, locationId)
+		
+		local mingui = not CHUDGetOption("mingui")
+		local frameBackground = ConditionalValue(mingui, "ui/alien_hivestatus_frame_bgs.dds", PrecacheAsset("ui/transparent.dds"))
+		local locationBackground = ConditionalValue(mingui, "ui/alien_hivestatus_locationname_bg.dds", "ui/transparent.dds")
+		
+		self.statusSlots[slotIdx].frame:SetTexture(frameBackground)
+		self.statusSlots[slotIdx].locationBackground:SetTexture(locationBackground)
+	end)


### PR DESCRIPTION
Add a new option to completely disable the hive status UI.
The existing minimal GUI option now removes some background elements
from the hive status UI.