### PR TITLE
Option dependency chains longer than two are handled better

### DIFF
--- a/lua/NS2Plus/Client/CHUD_MainMenu.lua
+++ b/lua/NS2Plus/Client/CHUD_MainMenu.lua
@@ -103,29 +103,37 @@ local function CHUDSaveMenuSetting(name)
 			end
 			
 			CHUDMenuOption.resetOption:SetIsVisible(CHUDMenuOption:GetIsVisible() and CHUDOption.defaultValue ~= CHUDOption.currentValue)
-			
-			if CHUDOption.children then
-				local show = true
-				for _, value in pairs(CHUDOption.hideValues) do
-					if CHUDOption.currentValue == value then
+
+			-- Show or hide an option's children (and their children...) as appropriate
+			local function PropagateVisibility(CHUDOption)
+				if CHUDOption.children then
+					local show = true
+					for _, value in pairs(CHUDOption.hideValues) do
+						if CHUDOption.currentValue == value then
+							show = false
+						end
+					end
+					
+					local CHUDMenuOption = mainMenu.CHUDOptionElements[CHUDOption["name"]]
+
+					-- Hide children options if the parent is also hidden
+					if CHUDMenuOption:GetIsVisible() == false then
 						show = false
 					end
-				end
-				
-				-- Hide children options if the parent is also hidden
-				if CHUDMenuOption:GetIsVisible() == false then
-					show = false
-				end
-				
-				for _, option in pairs(CHUDOption.children) do
-					local optionName = CHUDGetOptionParam(option, "name")
-					if optionName then
-						CHUDSetOptionVisible(mainMenu.CHUDOptionElements[optionName], show)
+
+					for _, option in pairs(CHUDOption.children) do
+						local optionName = CHUDGetOptionParam(option, "name")
+						if optionName then
+							CHUDSetOptionVisible(mainMenu.CHUDOptionElements[optionName], show)
+
+							PropagateVisibility(CHUDOptions[option])
+						end
 					end
 				end
-				
-				CHUDResortForm()
 			end
+
+			PropagateVisibility(CHUDOption)
+			CHUDResortForm()
 		end
 	end
 end

--- a/lua/NS2Plus/Client/CHUD_Settings.lua
+++ b/lua/NS2Plus/Client/CHUD_Settings.lua
@@ -430,15 +430,9 @@ local function OnCommandPlusExport()
 			stats = 7,
 			misc = 8
 		}
-		
-		
-			for idx, option in pairs(CHUDOptions) do
-				if not OptionsMenuTable[option.category] then
-					OptionsMenuTable[option.category] = {}
-				end
-				table.insert(OptionsMenuTable[option.category], CHUDOptions[idx])
-			
-			-- Add the options that are hidden in the options menu here so we don't print them later
+
+		-- If an option has hidden children, add them (and their children...) to the skip table
+		local function SkipChildren(option)
 			if option.children then
 				local show = true
 				for _, value in pairs(option.hideValues) do
@@ -446,15 +440,31 @@ local function OnCommandPlusExport()
 						show = false
 					end
 				end
-				
+
+				-- Skip children if we skipped the parent
+				if skipOptions[option.name] then
+					show = false
+				end
+
 				for _, optionIndex in pairs(option.children) do
 					local optionName = CHUDGetOptionParam(optionIndex, "name")
 					if optionName and not show then
 						skipOptions[optionName] = true
+
+						SkipChildren(CHUDOptions[optionIndex])
 					end
 				end
 			end
+		end
+
+		for idx, option in pairs(CHUDOptions) do
+			if not OptionsMenuTable[option.category] then
+				OptionsMenuTable[option.category] = {}
+			end
+			table.insert(OptionsMenuTable[option.category], CHUDOptions[idx])
 			
+			-- Add the options that are hidden in the options menu here so we don't print them later
+			SkipChildren(option)
 		end
 		
 		local function CHUDOptionsSort(a, b)


### PR DESCRIPTION
Options can have children. This relationship is used in two ways that I can see. When a parent has a certain value (typically the default value), its children:

1. are not displayed in the settings menu; and
2. are not printed with `plus_export`.

Currently this only works for two levels. Options can have children, but if those children have children (aka grandchildren), those grandchildren will not be affected when their grandparent changes. This can cause inactive settings to display in the menu and to be exported.  


This PR allows behaviors 1. and 2. to work for parent-child relationships of any length. For example, deactivating a grandfather option will hide its children and grandchildren, even if a grandchild has a parent that is set to active.

Some notes:

- I wasn't sure what to name the new local functions. The names I gave them probably suck.