### PR TITLE
Add per-lifeform sensitivity for aliens

### DIFF
--- a/lua/NS2Plus/CHUD_Client.lua
+++ b/lua/NS2Plus/CHUD_Client.lua
@@ -73,6 +73,7 @@ end
 local function OnLocalPlayerChanged()
 	CHUDLoadLights()
 	CHUDEvaluateGUIVis()
+	CHUDApplyLifeformSpecificStuff()
 end
 
 -- Apparently NS2 doesn't always call OnLocalPlayerChanged when changing teams, so this

--- a/lua/NS2Plus/Client/CHUD_Options.lua
+++ b/lua/NS2Plus/Client/CHUD_Options.lua
@@ -1346,7 +1346,7 @@ CHUDOptions =
 				applyFunction = function()
 					CHUDApplyTeamSpecificStuff()
 				end,
-				children = { "sensitivity_m", "sensitivity_a" },
+				children = { "sensitivity_m", "sensitivity_a", "sensitivity_perlifeform" },
 				hideValues = { false },
 				sort = "A04",
 				ignoreCasterMode = true,
@@ -1381,8 +1381,115 @@ CHUDOptions =
 				valueType = "float",
 				applyFunction = function()
 					CHUDApplyTeamSpecificStuff()
+					CHUDApplyLifeformSpecificStuff()
 				end,
 				sort = "A06",
+				ignoreCasterMode = true,
+			},
+			sensitivity_perlifeform = {
+				name = "CHUD_SensitivityPerLifeform",
+				label = "Lifeform specific sensitivities",
+				tooltip = "Lets you have different sensitivities for each alien lifeform. Overrides Alien sensitivity above.",
+				type = "select",
+				values = { "Off", "On" },
+				defaultValue = false,
+				category = "misc",
+				valueType = "bool",
+				applyFunction = function()
+					CHUDApplyLifeformSpecificStuff()
+				end,
+				children = {
+					"sensitivity_skulk", "sensitivity_gorge",
+					"sensitivity_lerk", "sensitivity_fade",
+					"sensitivity_onos"
+				},
+				hideValues = { false },
+				sort = "A06.1",
+				ignoreCasterMode = true,
+			},
+			sensitivity_skulk = {
+				name = "CHUD_Sensitivity_Skulk",
+				label = "Skulk sensitivity",
+				tooltip = "Sensitivity for Skulk.",
+				type = "slider",
+				defaultValue = 2,
+				minValue = 0.01,
+				maxValue = 20,
+				multiplier = 1,
+				category = "misc",
+				valueType = "float",
+				applyFunction = function()
+					CHUDApplyLifeformSpecificStuff()
+				end,
+				sort = "A06.2",
+				ignoreCasterMode = true,
+			},
+			sensitivity_gorge = {
+				name = "CHUD_Sensitivity_Gorge",
+				label = "Gorge sensitivity",
+				tooltip = "Sensitivity for Gorge.",
+				type = "slider",
+				defaultValue = 2,
+				minValue = 0.01,
+				maxValue = 20,
+				multiplier = 1,
+				category = "misc",
+				valueType = "float",
+				applyFunction = function()
+					CHUDApplyLifeformSpecificStuff()
+				end,
+				sort = "A06.3",
+				ignoreCasterMode = true,
+			},
+			sensitivity_lerk = {
+				name = "CHUD_Sensitivity_Lerk",
+				label = "Lerk sensitivity",
+				tooltip = "Sensitivity for Lerk.",
+				type = "slider",
+				defaultValue = 2,
+				minValue = 0.01,
+				maxValue = 20,
+				multiplier = 1,
+				category = "misc",
+				valueType = "float",
+				applyFunction = function()
+					CHUDApplyLifeformSpecificStuff()
+				end,
+				sort = "A06.4",
+				ignoreCasterMode = true,
+			},
+			sensitivity_fade = {
+				name = "CHUD_Sensitivity_Fade",
+				label = "Fade sensitivity",
+				tooltip = "Sensitivity for Fade.",
+				type = "slider",
+				defaultValue = 2,
+				minValue = 0.01,
+				maxValue = 20,
+				multiplier = 1,
+				category = "misc",
+				valueType = "float",
+				applyFunction = function()
+					CHUDApplyLifeformSpecificStuff()
+				end,
+				sort = "A06.5",
+				ignoreCasterMode = true,
+			},
+			sensitivity_onos = {
+				name = "CHUD_Sensitivity_Onos",
+				label = "Onos sensitivity",
+				tooltip = "Sensitivity for Onos.",
+				type = "slider",
+				defaultValue = 2,
+				minValue = 0.01,
+				maxValue = 20,
+				multiplier = 1,
+				category = "misc",
+				valueType = "float",
+				applyFunction = function()
+					CHUDApplyLifeformSpecificStuff()
+				end,
+				sort = "A06.6",
 				ignoreCasterMode = true,
 			},
 			fov_perteam = { 

--- a/lua/NS2Plus/Shared/CHUD_Utility.lua
+++ b/lua/NS2Plus/Shared/CHUD_Utility.lua
@@ -318,12 +318,37 @@ if Client then
 		local sensitivity_perteam = CHUDGetOption("sensitivity_perteam")
 		local fov_perteam = CHUDGetOption("fov_perteam")
 		
-		if CHUDGetOption("sensitivity_perteam") then
+		-- Aliens with per-lifeform sens will have it set separately.
+		if CHUDGetOption("sensitivity_perteam") and
+			(isMarine or not CHUDGetOption("sensitivity_perlifeform")) then
+
 			OptionsDialogUI_SetMouseSensitivity(sensitivity)
 		end
 		
 		if CHUDGetOption("fov_perteam") then
 			Client.SetOptionFloat("graphics/display/fov-adjustment", fov)
+		end
+	end
+
+	function CHUDApplyLifeformSpecificStuff()
+		local player = Client.GetLocalPlayer()
+		local eggTechId = player:isa("Embryo") and player:GetGestationTechId()
+		local sensitivity
+
+		if player:isa("Skulk") or eggTechId == kTechId.Skulk then
+			sensitivity = CHUDGetOption("sensitivity_skulk")
+		elseif player:isa("Gorge") or eggTechId == kTechId.Gorge then
+			sensitivity = CHUDGetOption("sensitivity_gorge")
+		elseif player:isa("Lerk") or eggTechId == kTechId.Lerk then
+			sensitivity = CHUDGetOption("sensitivity_lerk")
+		elseif player:isa("Fade") or eggTechId == kTechId.Fade then
+			sensitivity = CHUDGetOption("sensitivity_fade")
+		elseif player:isa("Onos") or eggTechId == kTechId.Onos then
+			sensitivity = CHUDGetOption("sensitivity_onos")
+		end
+
+		if CHUDGetOption("sensitivity_perlifeform") and sensitivity then
+			OptionsDialogUI_SetMouseSensitivity(sensitivity)
 		end
 	end
 	


### PR DESCRIPTION
Aliens can now have a different sensitivity for each lifeform by setting "Lifeform specific sensitivities" to "On" in the menu. Sensitivity sliders for skulk, gorge, lerk, fade, and onos will appear. This option is hidden if "Team specific sensitivities" is "Off".

Some notes:
- This PR introduces a parent-child option tree with three levels (for example `sensitivity_perteam`>`sensitivity_perlifeform`>`sensitivity_skulk`). Currently this means you can hide `sensitivity_perteam`, which will hide `sensitivity_perlifeform` appropriately, but `sensitivity_skulk` will still be displayed. Please see https://github.com/sclark39/NS2Plus/pull/55 for a method of addressing that.
- Enabling `sensitivity_perlifeform` overrides `sensitivity_a`, but `sensitivity_a` will still be displayed. It feels wrong to display an option that doesn't do anything, but I couldn't come up with a better solution. The tooltip for `sensitivity_perlifeform` mentions this behavior, at least.
- I used the `LocalPlayerChanged` hook to determine when to change sensitivity. According to a comment right below that, it doesn't always get called when changing teams. I never discovered the case where it doesn't get called, so I'm not sure if that's a problem here.