### PR TITLE
Adjust the hivestatus option entry to behave like other GUI options

### DIFF
--- a/lua/NS2Plus/Client/CHUD_Options.lua
+++ b/lua/NS2Plus/Client/CHUD_Options.lua
@@ -180,15 +180,15 @@ CHUDOptions =
 				label = "Alien Hive Status UI",
 				tooltip = "Enables or disables the hive status display in the top left of the alien HUD.",
 				type = "select",
-				values = { "On", "Off" },
-				defaultValue = false,
+				values = { "Off", "On" },
+				defaultValue = true,
 				category = "ui",
 				valueType = "bool",
 				applyFunction = function() CHUDRestartScripts({
 					"GUIHiveStatus",
 					}) end,
 				sort = "B00.5",
-				resetSettingInBuild = 373,
+				resetSettingInBuild = 375,
 			},
 			minimap = {
 				name = "CHUD_Minimap",

--- a/lua/NS2Plus/GUIScripts/GUIHiveStatus.lua
+++ b/lua/NS2Plus/GUIScripts/GUIHiveStatus.lua
@@ -2,7 +2,7 @@ local originalInit = GUIHiveStatus.Initialize
 function GUIHiveStatus:Initialize()
 	originalInit(self)
 
-	local hivestatus = not CHUDGetOption("hivestatus")
+	local hivestatus = CHUDGetOption("hivestatus")
 
 	self:SetIsVisible(hivestatus)
 end


### PR DESCRIPTION
I clearly wasn't paying attention when I made issue #49, or I would have noticed what the commit referenced there was trying to do (but only partially accomplished). Anyway, this PR puts the options entry in line with the other GUI options, while still keeping the option's desired behavior.

Also resets the option in build 375, since this will flip everybody's setting.