### PR TITLE
Replace a C-style comment with Lua-style

### DIFF
--- a/lua/NS2Plus/Client/CHUD_PlayerClient.lua
+++ b/lua/NS2Plus/Client/CHUD_PlayerClient.lua
@@ -20,12 +20,12 @@ originalUpdateScreenEff = Class_ReplaceMethod( "Player", "UpdateScreenEffects",
 -- Disables low health effects
 function UpdateDSPEffects()
 	-- We're not doing anything in this function
-    -- but leave this for future generations to wonder why this was an option in the first place
+	-- but leave this for future generations to wonder why this was an option in the first place
 
-    -- Most ancient piece of code in this mod - Archaeologists pls be careful, this code has a curse
-	/*if Client.GetOptionBoolean("CHUD_LowHealthEff", true) then
-		originalDSPEff()
-	end*/
+	-- Most ancient piece of code in this mod - Archaeologists pls be careful, this code has a curse
+	--if Client.GetOptionBoolean("CHUD_LowHealthEff", true) then
+		--originalDSPEff()
+	--end
 end
 
 local lastIngameNumPlayers = 0


### PR DESCRIPTION
also use consistent spacing there

Maybe you want to reject this commit and keep the function untouched
for future archaeologists. Totally understandable.