### PR TITLE
Disable some screen-occluding effects from tunnels and embryos

### DIFF
--- a/lua/NS2Plus/Client/CHUD_Particles.lua
+++ b/lua/NS2Plus/Client/CHUD_Particles.lua
@@ -151,6 +151,7 @@ local blockedCinematics = set {
 							"cinematics/alien/fade/trail_dark_2.cinematic",
 							"cinematics/alien/fade/trail_light_1.cinematic",
 							"cinematics/alien/fade/trail_light_2.cinematic",
+							"cinematics/alien/tunnel/entrance_use_1p.cinematic",
 							"cinematics/death_1p.cinematic",
 							"cinematics/marine/commander_arrow.cinematic",
 							"cinematics/marine/exo/hurt_severe_view.cinematic",

--- a/lua/NS2Plus/Client/CHUD_PlayerClient.lua
+++ b/lua/NS2Plus/Client/CHUD_PlayerClient.lua
@@ -8,14 +8,15 @@ originalBlur = Class_ReplaceMethod( "Player", "SetBlurEnabled",
 	end
 )
 
+--[[
 originalUpdateScreenEff = Class_ReplaceMethod( "Player", "UpdateScreenEffects",
 	function(self, deltaTime)
 		originalUpdateScreenEff(self, deltaTime)
-		--if not Client.GetOptionBoolean("CHUD_LowHealthEff", true) then
-			Player.screenEffects.lowHealth:SetActive(false)
-		--end
+
+		Player.screenEffects.lowHealth:SetActive(false)
 	end
 )
+--]]
 
 local originalSESetActive
 originalSESetActive = Class_ReplaceMethod("ScreenEffect", "SetActive",

--- a/lua/NS2Plus/Client/CHUD_PlayerClient.lua
+++ b/lua/NS2Plus/Client/CHUD_PlayerClient.lua
@@ -17,6 +17,17 @@ originalUpdateScreenEff = Class_ReplaceMethod( "Player", "UpdateScreenEffects",
 	end
 )
 
+local originalSESetActive
+originalSESetActive = Class_ReplaceMethod("ScreenEffect", "SetActive",
+	function(self, setActive)
+		if self == Player.screenEffects.gorgetunnel then
+			setActive = false
+		end
+
+		originalSESetActive(self, setActive)
+	end
+)
+
 -- Disables low health effects
 function UpdateDSPEffects()
 	-- We're not doing anything in this function


### PR DESCRIPTION
1. Disable the "gorgetunnel" screen effect. It's played when hatching from an egg, and also when you enter or exit a tunnel. This one looks like you're coming out of an amniotic sac. I made it always disabled, with no way to enable it. To me it seems analogous to the low health effect, which was also forcibly disabled. I'm open to suggestions about whether to make it user-settable, and where to put the option.  

2. Stop disabling the "lowHealth" screen effect, which vanilla removed a while ago.

3. Add tunnel cinematic to the list blocked by 'particles' option. It's played as you enter or exit a tunnel. This one adds some relatively static spots and junk.  

1 and 3 could maybe be considered to affect balance. The removal of these effects might significantly decrease the time it takes for players to orient themselves coming out of eggs and tunnels, allowing them to target enemies more quickly. Personally I think it's just annoying to look at, so I'm in favor of removal. Maybe this is a good place to ask whether removing the phasegate screen effect (the "warp") would be welcome too.

