### PR TITLE
Ignore per-lifeform sens if per-team sens is disabled

### DIFF
--- a/lua/NS2Plus/Shared/CHUD_Utility.lua
+++ b/lua/NS2Plus/Shared/CHUD_Utility.lua
@@ -333,6 +333,7 @@ if Client then
 	function CHUDApplyLifeformSpecificStuff()
 		local player = Client.GetLocalPlayer()
 		local eggTechId = player:isa("Embryo") and player:GetGestationTechId()
+		local sensitivity_perlifeform = CHUDGetOption("sensitivity_perteam") and CHUDGetOption("sensitivity_perlifeform")
 		local sensitivity
 
 		if player:isa("Skulk") or eggTechId == kTechId.Skulk then
@@ -347,7 +348,7 @@ if Client then
 			sensitivity = CHUDGetOption("sensitivity_onos")
 		end
 
-		if CHUDGetOption("sensitivity_perlifeform") and sensitivity then
+		if sensitivity_perlifeform and sensitivity then
 			OptionsDialogUI_SetMouseSensitivity(sensitivity)
 		end
 	end


### PR DESCRIPTION
Previously, if you enabled per-lifeform sens but disabled per-team
sens, your custom sens would still be applied when you changed
lifeform. Per-lifeform is a child option of per-team so that's
not ok.

this fix is for cr4zy but other people can use it too I guess