### PR TITLE
Revert "Ignore per-lifeform sens if per-team sens is disabled"

### DIFF
--- a/lua/NS2Plus/Shared/CHUD_Utility.lua
+++ b/lua/NS2Plus/Shared/CHUD_Utility.lua
@@ -333,7 +333,6 @@ if Client then
 	function CHUDApplyLifeformSpecificStuff()
 		local player = Client.GetLocalPlayer()
 		local eggTechId = player:isa("Embryo") and player:GetGestationTechId()
-		local sensitivity_perlifeform = CHUDGetOption("sensitivity_perteam") and CHUDGetOption("sensitivity_perlifeform")
 		local sensitivity
 
 		if player:isa("Skulk") or eggTechId == kTechId.Skulk then
@@ -348,7 +347,7 @@ if Client then
 			sensitivity = CHUDGetOption("sensitivity_onos")
 		end
 
-		if sensitivity_perlifeform and sensitivity then
+		if CHUDGetOption("sensitivity_perlifeform") and sensitivity then
 			OptionsDialogUI_SetMouseSensitivity(sensitivity)
 		end
 	end


### PR DESCRIPTION
Reverts sclark39/NS2Plus#64
It doesn't seem to work.  I tried it as an alien just now, and setting the alien team sensitivity to 20, then disabling the option didn't result in the sensitivity returning to the original value.