### PR TITLE
Fix overhead research tooltips showing incorrect time after completion

### DIFF
--- a/lua/NS2Plus/GUIScripts/Commander_Client.lua
+++ b/lua/NS2Plus/GUIScripts/Commander_Client.lua
@@ -46,6 +46,7 @@ local tooltipText
 local function displayTimeTooltip(tech)
     if GUIItemContainsPoint(tech.Icon, Client.GetCursorPosScreen()) then
         local timeLeft = tech.StartTime + tech.ResearchTime - Shared.GetTime()
+        timeLeft = timeLeft < 0 and 0 or timeLeft
         local minutes = math.floor(timeLeft/60)
         local seconds = math.ceil(timeLeft - minutes*60)
         tooltipText = string.format("%01.0f:%02.0f", minutes, seconds)

--- a/lua/NS2Plus/GUIScripts/GUIProduction.lua
+++ b/lua/NS2Plus/GUIScripts/GUIProduction.lua
@@ -10,6 +10,7 @@ local function displayNameTimeTooltip(tech)
 		local text = GetDisplayNameForTechId(tech.Id)
 		
 		local timeLeft = tech.StartTime + tech.ResearchTime - Shared.GetTime()
+		timeLeft = timeLeft < 0 and 0 or timeLeft
 		local minutes = math.floor(timeLeft/60)
 		local seconds = math.ceil(timeLeft - minutes*60)
 		tooltipText = string.format("%s - %01.0f:%02.0f", text, minutes, seconds)


### PR DESCRIPTION
The icon remains for about a second after research is complete. This
caused the "time remaining" to be negative and messed up the displayed
time.