### PR TITLE
Add finer options for drawing viewmodels

### DIFF
--- a/lua/NS2Plus/Client/CHUD_Options.lua
+++ b/lua/NS2Plus/Client/CHUD_Options.lua
@@ -1679,7 +1679,7 @@ CHUDOptions =
 					Client.SendNetworkMessage("SetCHUDAutopickup", message)
 				end,
 			},
-			drawviewmodel = { 
+			drawviewmodel = {
 				name = "CHUD_DrawViewModel",
 				label = "Draw viewmodel",
 				tooltip = "Enables or disables showing the viewmodel.",
@@ -1697,7 +1697,7 @@ CHUDOptions =
 				hideValues = { 0, 1 },
 				resetSettingInBuild = 290,
 			},
-			drawviewmodel_m = { 
+			drawviewmodel_m = {
 				name = "CHUD_DrawViewModel_M",
 				label = "Marine viewmodel",
 				tooltip = "Enables or disables showing the marine viewmodel.",
@@ -1712,21 +1712,7 @@ CHUDOptions =
 					CHUDRestartScripts({"Hud/Marine/GUIMarineHUD"})
 				end,
 			},
-			drawviewmodel_a = { 
-				name = "CHUD_DrawViewModel_A",
-				label = "Alien viewmodel",
-				tooltip = "Enables or disables showing the alien viewmodel.",
-				type = "select",
-				values  = { "Hide", "Display" },
-				defaultValue = true,
-				category = "misc",
-				valueType = "bool",
-				sort = "A14",
-				applyFunction = function()
-					CHUDEvaluateGUIVis()
-				end,
-			},
-			drawviewmodel_exo = { 
+			drawviewmodel_exo = {
 				name = "CHUD_DrawViewModel_Exo",
 				label = "Exo viewmodel",
 				tooltip = "Enables or disables showing the exo viewmodel.",
@@ -1735,10 +1721,100 @@ CHUDOptions =
 				defaultValue = true,
 				category = "misc",
 				valueType = "bool",
-				sort = "A15",
+				sort = "A13.1",
 				applyFunction = function()
 					CHUDEvaluateGUIVis()
 					CHUDRestartScripts({"Hud/Marine/GUIMarineHUD"})
+				end,
+			},
+			drawviewmodel_a = {
+				name = "CHUD_DrawViewModel_A",
+				label = "Alien viewmodel",
+				tooltip = "Enables or disables showing the alien viewmodel.",
+				type = "select",
+				values  = { "Display all", "Hide all", "Custom" },
+				defaultValue = 0,
+				category = "misc",
+				valueType = "int",
+				sort = "A14",
+				applyFunction = function()
+					CHUDEvaluateGUIVis()
+				end,
+				children = {
+					"drawviewmodel_skulk", "drawviewmodel_gorge",
+					"drawviewmodel_lerk", "drawviewmodel_fade",
+					"drawviewmodel_onos"
+				},
+				hideValues = { 0, 1 },
+			},
+			drawviewmodel_skulk = {
+				name = "CHUD_DrawViewModel_Skulk",
+				label = "Skulk viewmodel",
+				tooltip = "Enables or disables showing the Skulk viewmodel.",
+				type = "select",
+				values = { "Hide", "Display" },
+				defaultValue = true,
+				valueType = "bool",
+				category = "misc",
+				sort = "A14.1",
+				applyFunction = function()
+					CHUDEvaluateGUIVis()
+				end,
+			},
+			drawviewmodel_gorge = {
+				name = "CHUD_DrawViewModel_Gorge",
+				label = "Gorge viewmodel",
+				tooltip = "Enables or disables showing the Gorge viewmodel.",
+				type = "select",
+				values = { "Hide", "Display" },
+				defaultValue = true,
+				valueType = "bool",
+				category = "misc",
+				sort = "A14.2",
+				applyFunction = function()
+					CHUDEvaluateGUIVis()
+				end,
+			},
+			drawviewmodel_lerk = {
+				name = "CHUD_DrawViewModel_Lerk",
+				label = "Lerk viewmodel",
+				tooltip = "Enables or disables showing the Lerk viewmodel.",
+				type = "select",
+				values = { "Hide", "Display" },
+				defaultValue = true,
+				valueType = "bool",
+				category = "misc",
+				sort = "A14.3",
+				applyFunction = function()
+					CHUDEvaluateGUIVis()
+				end,
+			},
+			drawviewmodel_fade = {
+				name = "CHUD_DrawViewModel_Fade",
+				label = "Fade viewmodel",
+				tooltip = "Enables or disables showing the Fade viewmodel.",
+				type = "select",
+				values = { "Hide", "Display" },
+				defaultValue = true,
+				valueType = "bool",
+				category = "misc",
+				sort = "A14.4",
+				applyFunction = function()
+					CHUDEvaluateGUIVis()
+				end,
+			},
+			drawviewmodel_onos = {
+				name = "CHUD_DrawViewModel_Onos",
+				label = "Onos viewmodel",
+				tooltip = "Enables or disables showing the Onos viewmodel.",
+				type = "select",
+				values = { "Hide", "Display" },
+				defaultValue = true,
+				valueType = "bool",
+				category = "misc",
+				sort = "A14.5",
+				applyFunction = function()
+					CHUDEvaluateGUIVis()
 				end,
 			},
 			

--- a/lua/NS2Plus/Client/CHUD_ViewModel.lua
+++ b/lua/NS2Plus/Client/CHUD_ViewModel.lua
@@ -24,11 +24,21 @@ originalViewModelOnUpdateRender = Class_ReplaceMethod("ViewModel", "OnUpdateRend
 		
 		local player = Client.GetLocalPlayer()
 		local drawviewmodel = CHUDGetOption("drawviewmodel")
+		local drawviewmodel_a = CHUDGetOption("drawviewmodel_a")
 		gCHUDHiddenViewModel = drawviewmodel == 1 or
-			(drawviewmodel == 2 and
-				((player:isa("Marine") and not CHUDGetOption("drawviewmodel_m")) or
-				(player:isa("Alien") and not CHUDGetOption("drawviewmodel_a")) or
-				(player:isa("Exo") and not CHUDGetOption("drawviewmodel_exo")))
+			drawviewmodel == 2 and
+			(
+				player:isa("Marine") and not CHUDGetOption("drawviewmodel_m") or
+				player:isa("Exo") and not CHUDGetOption("drawviewmodel_exo") or
+				player:isa("Alien") and drawviewmodel_a ~= 0 and
+				(
+					drawviewmodel_a == 1 or
+					player:isa("Skulk") and not CHUDGetOption("drawviewmodel_skulk") or
+					player:isa("Gorge") and not CHUDGetOption("drawviewmodel_gorge") or
+					player:isa("Lerk") and not CHUDGetOption("drawviewmodel_lerk") or
+					player:isa("Fade") and not CHUDGetOption("drawviewmodel_fade") or
+					player:isa("Onos") and not CHUDGetOption("drawviewmodel_onos")
+				)
 			)
 		
 		self:SetIsVisible(trollModes["swalkMode"] or self:GetIsVisible() and not gCHUDHiddenViewModel)

--- a/lua/NS2Plus/Shared/CHUD_Utility.lua
+++ b/lua/NS2Plus/Shared/CHUD_Utility.lua
@@ -249,14 +249,24 @@ if Client then
 		
 		local teamNumber = player:GetTeamNumber()
 		local drawviewmodel = CHUDGetOption("drawviewmodel")
+		local drawviewmodel_a = CHUDGetOption("drawviewmodel_a")
 		-- Cannot use the gCHUDHiddenViewModel global as it changes in the frame after this is run
 		local isViewModelHidden = drawviewmodel == 1 or
-			(drawviewmodel == 2 and
-				((player:isa("Marine") and not CHUDGetOption("drawviewmodel_m")) or
-				(player:isa("Alien") and not CHUDGetOption("drawviewmodel_a")) or
-				(player:isa("Exo") and not CHUDGetOption("drawviewmodel_exo")))
+			drawviewmodel == 2 and
+			(
+				player:isa("Marine") and not CHUDGetOption("drawviewmodel_m") or
+				player:isa("Exo") and not CHUDGetOption("drawviewmodel_exo") or
+				player:isa("Alien") and drawviewmodel_a ~= 0 and
+				(
+					drawviewmodel_a == 1 or
+					player:isa("Skulk") and not CHUDGetOption("drawviewmodel_skulk") or
+					player:isa("Gorge") and not CHUDGetOption("drawviewmodel_gorge") or
+					player:isa("Lerk") and not CHUDGetOption("drawviewmodel_lerk") or
+					player:isa("Fade") and not CHUDGetOption("drawviewmodel_fade") or
+					player:isa("Onos") and not CHUDGetOption("drawviewmodel_onos")
+				)
 			)
-		
+
 		local classicammo = false
 		local customhud = false
 		local hiddenviewmodel = false


### PR DESCRIPTION
* Users can now choose to show or hide viewmodels for each lifeform
individually.

I'm thinking of doing something similar for marines but I'm not sure there is demand for it. And should it be per-weapon or per-slot? I'm open to suggestions about it.